### PR TITLE
modify server bootstrapping

### DIFF
--- a/examples/cloud-enabled/main.tf
+++ b/examples/cloud-enabled/main.tf
@@ -151,7 +151,7 @@ module "rke2" {
 
   ami                   = data.aws_ami.rhel8.image_id # Note: Multi OS is primarily for example purposes
   ssh_authorized_keys   = [tls_private_key.ssh.public_key_openssh]
-  asg                   = { min : 1, max : 5, desired : 3 }
+  servers               = 3
   instance_type         = "t3a.medium"
   controlplane_internal = false # Note this defaults to best practice of true, but is explicitly set to public for demo purposes
 

--- a/examples/quickstart/main.tf
+++ b/examples/quickstart/main.tf
@@ -56,6 +56,7 @@ module "rke2" {
   ami                   = data.aws_ami.rhel7.image_id
   ssh_authorized_keys   = [tls_private_key.ssh.public_key_openssh]
   controlplane_internal = false # Note this defaults to best practice of true, but is explicitly set to public for demo purposes
+  servers               = 5
 
   tags = local.tags
 }

--- a/examples/quickstart/main.tf
+++ b/examples/quickstart/main.tf
@@ -56,7 +56,7 @@ module "rke2" {
   ami                   = data.aws_ami.rhel7.image_id
   ssh_authorized_keys   = [tls_private_key.ssh.public_key_openssh]
   controlplane_internal = false # Note this defaults to best practice of true, but is explicitly set to public for demo purposes
-  servers               = 5
+  servers               = 1
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -75,14 +75,18 @@ module "cp_lb" {
 # Server Nodepool
 #
 module "servers" {
-  source               = "./modules/server-nodepool"
-  name                 = "${local.uname}-server"
-  vpc_id               = var.vpc_id
-  subnets              = var.subnets
-  ami                  = var.ami
-  ssh_authorized_keys  = var.ssh_authorized_keys
-  iam_instance_profile = var.iam_instance_profile
-  asg                  = var.asg
+  source = "./modules/server-nodepool"
+  name   = "${local.uname}-server"
+
+  vpc_id                = var.vpc_id
+  subnets               = var.subnets
+  ami                   = var.ami
+  ssh_authorized_keys   = var.ssh_authorized_keys
+  iam_instance_profile  = var.iam_instance_profile
+  block_device_mappings = var.block_device_mappings
+
+  # Don't allow the user to do something not recommended within etcd scaling, set max deliberately and only let them control desired
+  asg = { min : 1, max : 7, desired : var.servers }
 
   controlplane_allowed_cirds = var.controlplane_allowed_cidrs
   server_tg_arn              = module.cp_lb.server_tg_arn

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -11,9 +11,12 @@ resource "aws_launch_template" "this" {
   block_device_mappings {
     device_name = "/dev/sda1"
     ebs {
-      volume_size           = var.block_device_mappings.size
-      encrypted             = var.block_device_mappings.encrypted
-      delete_on_termination = true
+      volume_type           = lookup(var.block_device_mappings, "type", null)
+      volume_size           = lookup(var.block_device_mappings, "size", null)
+      iops                  = lookup(var.block_device_mappings, "iops", null)
+      kms_key_id            = lookup(var.block_device_mappings, "kms_key_id", null)
+      encrypted             = lookup(var.block_device_mappings, "encrypted", null)
+      delete_on_termination = lookup(var.block_device_mappings, "delete_on_termination", null)
     }
   }
 

--- a/modules/nodepool/variables.tf
+++ b/modules/nodepool/variables.tf
@@ -50,14 +50,11 @@ variable "vpc_security_group_ids" {
 }
 
 variable "block_device_mappings" {
-  type = object({
-    size      = number
-    encrypted = bool
-  })
+  type = map(string)
 
   default = {
-    "size"      = 30
-    "encrypted" = false
+    "size" = 30
+    type   = "gp2"
   }
 }
 

--- a/modules/server-nodepool/main.tf
+++ b/modules/server-nodepool/main.tf
@@ -66,6 +66,7 @@ data "aws_iam_policy_document" "aws_ccm" {
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeTags",
+      "autoscaling:DescribeAutoScalingInstances",
       "ec2:DescribeInstances",
       "ec2:DescribeRegions",
       "ec2:DescribeRouteTables",

--- a/variables.tf
+++ b/variables.tf
@@ -58,19 +58,10 @@ variable "block_device_mappings" {
   }
 }
 
-variable "asg" {
-  description = "Server pool Auto Scaling Group capacities"
-  type = object({
-    min     = number
-    max     = number
-    desired = number
-  })
-
-  default = {
-    min     = 1
-    max     = 9
-    desired = 1
-  }
+variable "servers" {
+  description = "Number of servers to create"
+  type        = number
+  default     = 1
 }
 
 variable "ssh_authorized_keys" {


### PR DESCRIPTION
Change server userdata:

* remove reliance on `ami_launch_index` for identifying bootstrapping leader
* use simple "leader election" (term used extremely lightly) to identify first server based off ASGs instance id (alphanumeric). anything after first asg scale event is handled by querying the apiserver health from the load balancer with `/dev/tcp`