### PR TITLE
remove redundant sts caller-identity check

### DIFF
--- a/modules/userdata/files/rke2-init.sh
+++ b/modules/userdata/files/rke2-init.sh
@@ -84,11 +84,6 @@ cp_wait() {
 fetch_token() {
   info "Fetching rke2 join token..."
 
-  # Validate aws caller identity, fatal if not valid
-  if ! aws sts get-caller-identity 2>/dev/null; then
-    fatal "No valid aws caller identity"
-  fi
-
   # Either
   #   a) fetch token from s3 bucket
   #   b) fail


### PR DESCRIPTION
Remove a redundant call given that the very next call fatals if aws s3 fails _for whatever reason_