### PR TITLE
Permissions boundary when creating IAM role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,9 +128,10 @@ resource "aws_security_group_rule" "server_cp_supervisor" {
 module "iam" {
   count = var.iam_instance_profile == "" ? 1 : 0
 
-  source = "./modules/policies"
-  name   = "${local.uname}-rke2-server"
-  tags   = merge({}, local.default_tags, var.tags)
+  source               = "./modules/policies"
+  name                 = "${local.uname}-rke2-server"
+  tags                 = merge({}, local.default_tags, var.tags)
+  permissions_boundary = var.permissions_boundary
 }
 
 #

--- a/modules/agent-nodepool/main.tf
+++ b/modules/agent-nodepool/main.tf
@@ -21,9 +21,10 @@ locals {
 module "iam" {
   count = var.iam_instance_profile == "" ? 1 : 0
 
-  source = "../policies"
-  name   = "${local.name}-rke2-agent"
-  tags   = merge({}, local.default_tags, var.tags)
+  source               = "../policies"
+  name                 = "${local.name}-rke2-agent"
+  tags                 = merge({}, local.default_tags, var.tags)
+  permissions_boundary = var.permissions_boundary
 }
 
 resource "aws_iam_role_policy" "aws_ccm" {

--- a/modules/agent-nodepool/variables.tf
+++ b/modules/agent-nodepool/variables.tf
@@ -135,3 +135,9 @@ variable "post_userdata" {
   type        = string
   default     = ""
 }
+
+variable "permissions_boundary" {
+  description = "If provided, all IAM roles will be created with this permissions boundary attached."
+  type        = string
+  default     = null
+}

--- a/modules/policies/main.tf
+++ b/modules/policies/main.tf
@@ -13,9 +13,10 @@ data "aws_iam_policy_document" "ec2_access" {
 }
 
 resource "aws_iam_role" "this" {
-  name               = var.name
-  assume_role_policy = data.aws_iam_policy_document.ec2_access.json
-  tags               = var.tags
+  name                 = var.name
+  assume_role_policy   = data.aws_iam_policy_document.ec2_access.json
+  tags                 = var.tags
+  permissions_boundary = var.permissions_boundary
 }
 
 #

--- a/modules/policies/variables.tf
+++ b/modules/policies/variables.tf
@@ -6,3 +6,9 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "permissions_boundary" {
+  description = "If provided, all IAM roles will be created with this permissions boundary attached."
+  type        = string
+  default     = null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,10 +43,10 @@ output "iam_instance_profile" {
   description = "IAM instance profile attached to server nodes"
   value       = var.iam_instance_profile == "" ? module.iam[0].iam_instance_profile : var.iam_instance_profile
 }
-  
+
 output "iam_role_arn" {
   description = "IAM role arn of server nodes"
-  value       =  var.iam_instance_profile == "" ? module.iam[0].role_arn : var.iam_instance_profile
+  value       = var.iam_instance_profile == "" ? module.iam[0].role_arn : var.iam_instance_profile
 }
 
 output "kubeconfig_path" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "ami" {
   type        = string
 }
 
+variable "permissions_boundary" {
+  description = "If provided, all IAM roles will be created with this permissions boundary attached."
+  type        = string
+  default     = null
+}
+
 variable "iam_instance_profile" {
   description = "Server pool IAM Instance Profile, created if left blank"
   type        = string


### PR DESCRIPTION
**What:**

* Adds the ability to use permissions boundaries when creating IAM roles using the policy module.

**Why:**

* In certain environments users are only allowed to create IAM roles with a permissions boundary attached. 

**Related Links:**

* Something similar is done for the `terraform-aws-eks` module [here](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/618019e331387ffb129d32af4c736e75477c9094/variables.tf#L244)


Tested in my own env successfully: 

![image](https://user-images.githubusercontent.com/40183093/103421115-c8a6f900-4b68-11eb-8fc6-e90384ee1c16.png)
