### PR TITLE
fix: add option to override device_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,7 @@ Optional policies have the option of being created by default, but are specified
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | ami | Server pool ami | `string` | n/a | yes |
-| block\_device\_mappings | Server pool block device mapping configuration | <pre>object({<br>    size      = number<br>    encrypted = bool<br>  })</pre> | <pre>{<br>  "encrypted": false,<br>  "size": 30<br>}</pre> | no |
-| cluster\_name | Name of the rkegov cluster to create | `string` | n/a | yes |
+| block\_device\_mappings | Server pool block device mapping configuration | `map(string)` | <pre>{<br>  "encrypted": false,<br>  "size": 30<br>}</pre> | no || cluster\_name | Name of the rkegov cluster to create | `string` | n/a | yes |
 | controlplane\_allowed\_cidrs | Server pool security group allowed cidr ranges | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | controlplane\_enable\_cross\_zone\_load\_balancing | Toggle between controlplane cross zone load balancing | `bool` | `true` | no |
 | controlplane\_internal | Toggle between public or private control plane load balancer | `bool` | `true` | no |

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -18,7 +18,7 @@ resource "aws_launch_template" "this" {
   vpc_security_group_ids = concat([aws_security_group.this.id], var.vpc_security_group_ids)
 
   block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = lookup(var.block_device_mappings, "device_name", "/dev/sda1")
     ebs {
       volume_type           = lookup(var.block_device_mappings, "type", null)
       volume_size           = lookup(var.block_device_mappings, "size", null)

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "iam_instance_profile" {
 
 variable "block_device_mappings" {
   description = "Server pool block device mapping configuration"
-  type = map(string)
+  type        = map(string)
   default = {
     "size"      = 30
     "encrypted" = false

--- a/variables.tf
+++ b/variables.tf
@@ -41,11 +41,7 @@ variable "iam_instance_profile" {
 
 variable "block_device_mappings" {
   description = "Server pool block device mapping configuration"
-  type = object({
-    size      = number
-    encrypted = bool
-  })
-
+  type = map(string)
   default = {
     "size"      = 30
     "encrypted" = false


### PR DESCRIPTION
Add optional `var.block_device_mappings.device_name` variable to override the default `/dev/sda1` value in the nodepool launch template.

Also change `block_device_mappings` type in `variables.tf` to match `modules/nodepool/variables.tf` and `modules/agent-nodepool/variables.tf` and allow for optional parameters.