### PR TITLE
Updated to allow for using multiple block device mappings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,14 @@ Optional policies have the option of being created by default, but are specified
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | ami | Server pool ami | `string` | n/a | yes |
-| block\_device\_mappings | Server pool block device mapping configuration | `map(string)` | <pre>{<br>  "encrypted": false,<br>  "size": 30<br>}</pre> | no || cluster\_name | Name of the rkegov cluster to create | `string` | n/a | yes |
+| block\_device\_mappings | Server pool block device mapping configuration | `map(string)` | <pre>{<br>  "encrypted": false,<br>  "size": 30<br>}</pre> | no |
+| cluster\_name | Name of the rkegov cluster to create | `string` | n/a | yes |
 | controlplane\_allowed\_cidrs | Server pool security group allowed cidr ranges | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | controlplane\_enable\_cross\_zone\_load\_balancing | Toggle between controlplane cross zone load balancing | `bool` | `true` | no |
 | controlplane\_internal | Toggle between public or private control plane load balancer | `bool` | `true` | no |
 | download | Toggle best effort download of rke2 dependencies (rke2 and aws cli), if disabled, dependencies are assumed to exist in $PATH | `bool` | `true` | no |
 | enable\_ccm | Toggle enabling the cluster as aws aware, this will ensure the appropriate IAM policies are present | `bool` | `false` | no |
+| extra\_block\_device\_mappings | Additional server pool block device mappings configuration | `list(map(string))` | <pre> [ ] </pre> | no |
 | iam\_instance\_profile | Server pool IAM Instance Profile, created if left blank (default behavior) | `string` | `""` | no |
 | iam\_permissions\_boundary | If provided, the IAM role created for the servers will be created with this permissions boundary attached. | `string` | `null` | no |
 | extra\_security\_group\_ids | List of additional security group IDs | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Optional policies have the option of being created by default, but are specified
 | controlplane\_internal | Toggle between public or private control plane load balancer | `bool` | `true` | no |
 | download | Toggle best effort download of rke2 dependencies (rke2 and aws cli), if disabled, dependencies are assumed to exist in $PATH | `bool` | `true` | no |
 | enable\_ccm | Toggle enabling the cluster as aws aware, this will ensure the appropriate IAM policies are present | `bool` | `false` | no |
-| extra\_block\_device\_mappings | Additional server pool block device mappings configuration | `list(map(string))` | <pre> [ ] </pre> | no |
+| extra\_block\_device\_mappings | Additional server pool block device mappings configuration | `list(map(string))` | `[]` | no |
 | iam\_instance\_profile | Server pool IAM Instance Profile, created if left blank (default behavior) | `string` | `""` | no |
 | iam\_permissions\_boundary | If provided, the IAM role created for the servers will be created with this permissions boundary attached. | `string` | `null` | no |
 | extra\_security\_group\_ids | List of additional security group IDs | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -178,15 +178,15 @@ module "servers" {
   source = "./modules/nodepool"
   name   = "${local.uname}-server"
 
-  vpc_id                 = var.vpc_id
-  subnets                = var.subnets
-  ami                    = var.ami
-  instance_type          = var.instance_type
-  block_device_mappings  = var.block_device_mappings
-  extra_block_device_mappings  = var.extra_block_device_mappings
-  vpc_security_group_ids = concat([aws_security_group.server.id, aws_security_group.cluster.id], var.extra_security_group_ids)
-  spot                   = var.spot
-  load_balancers         = [module.cp_lb.name]
+  vpc_id                      = var.vpc_id
+  subnets                     = var.subnets
+  ami                         = var.ami
+  instance_type               = var.instance_type
+  block_device_mappings       = var.block_device_mappings
+  extra_block_device_mappings = var.extra_block_device_mappings
+  vpc_security_group_ids      = concat([aws_security_group.server.id, aws_security_group.cluster.id], var.extra_security_group_ids)
+  spot                        = var.spot
+  load_balancers              = [module.cp_lb.name]
 
   # Overrideable variables
   userdata             = data.template_cloudinit_config.this.rendered

--- a/main.tf
+++ b/main.tf
@@ -183,6 +183,7 @@ module "servers" {
   ami                    = var.ami
   instance_type          = var.instance_type
   block_device_mappings  = var.block_device_mappings
+  extra_block_device_mappings  = var.extra_block_device_mappings
   vpc_security_group_ids = concat([aws_security_group.server.id, aws_security_group.cluster.id], var.extra_security_group_ids)
   spot                   = var.spot
   load_balancers         = [module.cp_lb.name]

--- a/modules/agent-nodepool/README.md
+++ b/modules/agent-nodepool/README.md
@@ -14,7 +14,7 @@
 | cluster\_data | Required data relevant to joining an existing rke2 cluster, sourced from main rke2 module, do NOT modify | <pre>object({<br>    name       = string<br>    server_url = string<br>    cluster_sg = string<br>    token = object({<br>      bucket          = string<br>      bucket_arn      = string<br>      object          = string<br>      policy_document = string<br>    })<br>  })</pre> | n/a | yes |
 | enable\_autoscaler | Toggle configure the nodepool for cluster autoscaler, this will ensure the appropriate IAM policies are present, you are still responsible for ensuring cluster autoscaler is installed | `bool` | `false` | no |
 | enable\_ccm | Toggle enabling the cluster as aws aware, this will ensure the appropriate IAM policies are present | `bool` | `false` | no |
-| extra\_block\_device\_mappings | Additional node pool block device mappings configuration | `list(map(string))` | <pre> [ ] </pre> | no |
+| extra\_block\_device\_mappings | Additional node pool block device mappings configuration | `list(map(string))` | `[]` | no |
 | extra\_security\_group\_ids | List of additional security group IDs | `list(string)` | `[]` | no |
 | iam\_instance\_profile | Node pool IAM Instance Profile, created if node specified | `string` | `""` | no |
 | instance\_type | Node pool instance type | `string` | `"t3.medium"` | no |

--- a/modules/agent-nodepool/README.md
+++ b/modules/agent-nodepool/README.md
@@ -14,6 +14,7 @@
 | cluster\_data | Required data relevant to joining an existing rke2 cluster, sourced from main rke2 module, do NOT modify | <pre>object({<br>    name       = string<br>    server_url = string<br>    cluster_sg = string<br>    token = object({<br>      bucket          = string<br>      bucket_arn      = string<br>      object          = string<br>      policy_document = string<br>    })<br>  })</pre> | n/a | yes |
 | enable\_autoscaler | Toggle configure the nodepool for cluster autoscaler, this will ensure the appropriate IAM policies are present, you are still responsible for ensuring cluster autoscaler is installed | `bool` | `false` | no |
 | enable\_ccm | Toggle enabling the cluster as aws aware, this will ensure the appropriate IAM policies are present | `bool` | `false` | no |
+| extra\_block\_device\_mappings | Additional node pool block device mappings configuration | `list(map(string))` | <pre> [ ] </pre> | no |
 | extra\_security\_group\_ids | List of additional security group IDs | `list(string)` | `[]` | no |
 | iam\_instance\_profile | Node pool IAM Instance Profile, created if node specified | `string` | `""` | no |
 | instance\_type | Node pool instance type | `string` | `"t3.medium"` | no |

--- a/modules/agent-nodepool/main.tf
+++ b/modules/agent-nodepool/main.tf
@@ -109,17 +109,17 @@ module "nodepool" {
   source = "../nodepool"
   name   = "${local.name}-agent"
 
-  vpc_id                 = var.vpc_id
-  subnets                = var.subnets
-  ami                    = var.ami
-  instance_type          = var.instance_type
-  block_device_mappings  = var.block_device_mappings
-  extra_block_device_mappings  = var.extra_block_device_mappings
-  vpc_security_group_ids = concat([var.cluster_data.cluster_sg], var.extra_security_group_ids)
-  userdata               = data.template_cloudinit_config.init.rendered
-  iam_instance_profile   = var.iam_instance_profile == "" ? module.iam[0].iam_instance_profile : var.iam_instance_profile
-  asg                    = var.asg
-  spot                   = var.spot
+  vpc_id                      = var.vpc_id
+  subnets                     = var.subnets
+  ami                         = var.ami
+  instance_type               = var.instance_type
+  block_device_mappings       = var.block_device_mappings
+  extra_block_device_mappings = var.extra_block_device_mappings
+  vpc_security_group_ids      = concat([var.cluster_data.cluster_sg], var.extra_security_group_ids)
+  userdata                    = data.template_cloudinit_config.init.rendered
+  iam_instance_profile        = var.iam_instance_profile == "" ? module.iam[0].iam_instance_profile : var.iam_instance_profile
+  asg                         = var.asg
+  spot                        = var.spot
 
   tags = merge({
     "Role" = "agent",

--- a/modules/agent-nodepool/main.tf
+++ b/modules/agent-nodepool/main.tf
@@ -114,6 +114,7 @@ module "nodepool" {
   ami                    = var.ami
   instance_type          = var.instance_type
   block_device_mappings  = var.block_device_mappings
+  extra_block_device_mappings  = var.extra_block_device_mappings
   vpc_security_group_ids = concat([var.cluster_data.cluster_sg], var.extra_security_group_ids)
   userdata               = data.template_cloudinit_config.init.rendered
   iam_instance_profile   = var.iam_instance_profile == "" ? module.iam[0].iam_instance_profile : var.iam_instance_profile

--- a/modules/agent-nodepool/variables.tf
+++ b/modules/agent-nodepool/variables.tf
@@ -63,9 +63,9 @@ variable "block_device_mappings" {
 
 variable "extra_block_device_mappings" {
   description = "Used to specify additional block device mapping configurations"
-   type = list(map(string))
-   default = [
-   ]
+  type        = list(map(string))
+  default = [
+  ]
 }
 
 variable "asg" {

--- a/modules/agent-nodepool/variables.tf
+++ b/modules/agent-nodepool/variables.tf
@@ -61,6 +61,13 @@ variable "block_device_mappings" {
   }
 }
 
+variable "extra_block_device_mappings" {
+  description = "Used to specify additional block device mapping configurations"
+   type = list(map(string))
+   default = [
+   ]
+}
+
 variable "asg" {
   description = "Node pool AutoScalingGroup scaling definition"
   type = object({

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -20,14 +20,14 @@ resource "aws_launch_template" "this" {
   dynamic "block_device_mappings" {
     for_each = concat([var.block_device_mappings],var.extra_block_device_mappings)
     content {
-      device_name = lookup(var.block_device_mappings, "device_name", "/dev/sda1")
+      device_name = lookup(block_device_mappings, "device_name", "/dev/sda1")
       ebs {
-        volume_type           = lookup(var.block_device_mappings, "type", null)
-        volume_size           = lookup(var.block_device_mappings, "size", null)
-        iops                  = lookup(var.block_device_mappings, "iops", null)
-        kms_key_id            = lookup(var.block_device_mappings, "kms_key_id", null)
-        encrypted             = lookup(var.block_device_mappings, "encrypted", null)
-        delete_on_termination = lookup(var.block_device_mappings, "delete_on_termination", null)
+        volume_type           = lookup(block_device_mappings, "type", null)
+        volume_size           = lookup(block_device_mappings, "size", null)
+        iops                  = lookup(block_device_mappings, "iops", null)
+        kms_key_id            = lookup(block_device_mappings, "kms_key_id", null)
+        encrypted             = lookup(block_device_mappings, "encrypted", null)
+        delete_on_termination = lookup(block_device_mappings, "delete_on_termination", null)
       }
     }
   }

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -17,15 +17,18 @@ resource "aws_launch_template" "this" {
   user_data              = var.userdata
   vpc_security_group_ids = concat([aws_security_group.this.id], var.vpc_security_group_ids)
 
-  block_device_mappings {
-    device_name = lookup(var.block_device_mappings, "device_name", "/dev/sda1")
-    ebs {
-      volume_type           = lookup(var.block_device_mappings, "type", null)
-      volume_size           = lookup(var.block_device_mappings, "size", null)
-      iops                  = lookup(var.block_device_mappings, "iops", null)
-      kms_key_id            = lookup(var.block_device_mappings, "kms_key_id", null)
-      encrypted             = lookup(var.block_device_mappings, "encrypted", null)
-      delete_on_termination = lookup(var.block_device_mappings, "delete_on_termination", null)
+  dynamic "block_device_mappings" {
+    for_each = concat([var.block_device_mappings],var.extra_block_device_mappings)
+    content {
+      device_name = lookup(var.block_device_mappings, "device_name", "/dev/sda1")
+      ebs {
+        volume_type           = lookup(var.block_device_mappings, "type", null)
+        volume_size           = lookup(var.block_device_mappings, "size", null)
+        iops                  = lookup(var.block_device_mappings, "iops", null)
+        kms_key_id            = lookup(var.block_device_mappings, "kms_key_id", null)
+        encrypted             = lookup(var.block_device_mappings, "encrypted", null)
+        delete_on_termination = lookup(var.block_device_mappings, "delete_on_termination", null)
+      }
     }
   }
 

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -17,10 +17,22 @@ resource "aws_launch_template" "this" {
   user_data              = var.userdata
   vpc_security_group_ids = concat([aws_security_group.this.id], var.vpc_security_group_ids)
 
+  block_device_mappings {
+    device_name = lookup(var.block_device_mappings, "device_name", "/dev/sda1")
+    ebs {
+      volume_type           = lookup(var.block_device_mappings, "type", null)
+      volume_size           = lookup(var.block_device_mappings, "size", null)
+      iops                  = lookup(var.block_device_mappings, "iops", null)
+      kms_key_id            = lookup(var.block_device_mappings, "kms_key_id", null)
+      encrypted             = lookup(var.block_device_mappings, "encrypted", null)
+      delete_on_termination = lookup(var.block_device_mappings, "delete_on_termination", null)
+    }
+  }
+
   dynamic "block_device_mappings" {
-    for_each = concat([var.block_device_mappings], var.extra_block_device_mappings)
+    for_each = var.extra_block_device_mappings
     content {
-      device_name = lookup(block_device_mappings.value, "device_name", "/dev/sda1")
+      device_name = lookup(block_device_mappings.value, "device_name", "null")
       ebs {
         volume_type           = lookup(block_device_mappings.value, "type", null)
         volume_size           = lookup(block_device_mappings.value, "size", null)

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -20,14 +20,14 @@ resource "aws_launch_template" "this" {
   dynamic "block_device_mappings" {
     for_each = concat([var.block_device_mappings],var.extra_block_device_mappings)
     content {
-      device_name = lookup(block_device_mappings, "device_name", "/dev/sda1")
+      device_name = lookup(block_device_mappings.value, "device_name", "/dev/sda1")
       ebs {
-        volume_type           = lookup(block_device_mappings, "type", null)
-        volume_size           = lookup(block_device_mappings, "size", null)
-        iops                  = lookup(block_device_mappings, "iops", null)
-        kms_key_id            = lookup(block_device_mappings, "kms_key_id", null)
-        encrypted             = lookup(block_device_mappings, "encrypted", null)
-        delete_on_termination = lookup(block_device_mappings, "delete_on_termination", null)
+        volume_type           = lookup(block_device_mappings.value, "type", null)
+        volume_size           = lookup(block_device_mappings.value, "size", null)
+        iops                  = lookup(block_device_mappings.value, "iops", null)
+        kms_key_id            = lookup(block_device_mappings.value, "kms_key_id", null)
+        encrypted             = lookup(block_device_mappings.value, "encrypted", null)
+        delete_on_termination = lookup(block_device_mappings.value, "delete_on_termination", null)
       }
     }
   }

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -18,7 +18,7 @@ resource "aws_launch_template" "this" {
   vpc_security_group_ids = concat([aws_security_group.this.id], var.vpc_security_group_ids)
 
   dynamic "block_device_mappings" {
-    for_each = concat([var.block_device_mappings],var.extra_block_device_mappings)
+    for_each = concat([var.block_device_mappings], var.extra_block_device_mappings)
     content {
       device_name = lookup(block_device_mappings.value, "device_name", "/dev/sda1")
       ebs {

--- a/modules/nodepool/variables.tf
+++ b/modules/nodepool/variables.tf
@@ -64,9 +64,9 @@ variable "block_device_mappings" {
 }
 
 variable "extra_block_device_mappings" {
-   type = list(map(string))
-   default = [
-   ]
+  type = list(map(string))
+  default = [
+  ]
 }
 
 variable "asg" {

--- a/modules/nodepool/variables.tf
+++ b/modules/nodepool/variables.tf
@@ -63,6 +63,12 @@ variable "block_device_mappings" {
   }
 }
 
+variable "extra_block_device_mappings" {
+   type = list(map(string))
+   default = [
+   ]
+}
+
 variable "asg" {
   type = object({
     min     = number

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,13 @@ variable "block_device_mappings" {
   }
 }
 
+variable "extra_block_device_mappings" {
+  description = "Used to specify additional block device mapping configurations"
+   type = list(map(string))
+   default = [
+   ]
+}
+
 variable "servers" {
   description = "Number of servers to create"
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -56,9 +56,9 @@ variable "block_device_mappings" {
 
 variable "extra_block_device_mappings" {
   description = "Used to specify additional block device mapping configurations"
-   type = list(map(string))
-   default = [
-   ]
+  type        = list(map(string))
+  default = [
+  ]
 }
 
 variable "servers" {


### PR DESCRIPTION

Updated to allow for use of multiple block device mappings [in accordance with this interface](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#block_device_mappings)
 while maintaining backwards compatibility with previous versions of RKE2-AWS-TF.



For review by @AbrohamLincoln 