### PR TITLE
Expose flag to control unique suffix generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Optional policies have the option of being created by default, but are specified
 | ami | Server pool ami | `string` | n/a | yes |
 | block\_device\_mappings | Server pool block device mapping configuration | `map(string)` | <pre>{<br>  "encrypted": false,<br>  "size": 30<br>}</pre> | no |
 | cluster\_name | Name of the rkegov cluster to create | `string` | n/a | yes |
+| unique\_suffix | Enables/disables generation of a unique suffix to cluster name | `bool` | `true` | yes |
 | controlplane\_allowed\_cidrs | Server pool security group allowed cidr ranges | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | controlplane\_enable\_cross\_zone\_load\_balancing | Toggle between controlplane cross zone load balancing | `bool` | `true` | no |
 | controlplane\_internal | Toggle between public or private control plane load balancer | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   # Create a unique cluster name we'll prefix to all resources created and ensure it's lowercase
-  uname = lower("${var.cluster_name}-${random_string.uid.result}")
+  uname = var.unique_suffix ? lower("${var.cluster_name}-${random_string.uid.result}") : lower(var.cluster_name)
 
   default_tags = {
     "ClusterType" = "rke2",

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "unique_suffix" {
+  description = "Enables/disables generation of a unique suffix to cluster name"
+  type        = bool
+  default     = true
+}
+
 variable "vpc_id" {
   description = "VPC ID to create resources in"
   type        = string


### PR DESCRIPTION
We need this feature for 2 use cases:

1. We create resources prior to the RKE2 terraform and want all of the names to match so we already need to control the uniqueness ourselves.
2. In the event of a runner failure when the state fails to update, a subsequent run with the suffix generation will create a whole second set of infra.