### PR TITLE
Expose variable for control plane access logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module "rke2_agents" {
   vpc_id  = "vpc-###"
   subnets = ["subnet-###"]
   ami     = "ami-###"
-  
+
   # Required input sourced from parent rke2 module, contains configuration that agents use to join existing cluster
   cluster_data = module.rke2.cluster_data
 }
@@ -98,7 +98,7 @@ Servers and agents need to be able to fetch the cluster join token
 }
 ```
 
-**Note:** The S3 bucket will be dynamically created during cluster creation, in order to pre create an iam policy that points to this bucket, the use of wildcards is recommended. 
+**Note:** The S3 bucket will be dynamically created during cluster creation, in order to pre create an iam policy that points to this bucket, the use of wildcards is recommended.
 For example: `s3:::us-gov-west-1:${var.cluster_name}-*`
 
 ##### Get Autoscaling Instances
@@ -154,7 +154,7 @@ Optional policies have the option of being created by default, but are specified
 | ami | Server pool ami | `string` | n/a | yes |
 | block\_device\_mappings | Server pool block device mapping configuration | `map(string)` | <pre>{<br>  "encrypted": false,<br>  "size": 30<br>}</pre> | no |
 | cluster\_name | Name of the rkegov cluster to create | `string` | n/a | yes |
-| unique\_suffix | Enables/disables generation of a unique suffix to cluster name | `bool` | `true` | yes |
+| controlplane\_access\_logs\_bucket | Set to bucket name to log requests to load balancer | `string` | `"disabled"` | no |
 | controlplane\_allowed\_cidrs | Server pool security group allowed cidr ranges | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | controlplane\_enable\_cross\_zone\_load\_balancing | Toggle between controlplane cross zone load balancing | `bool` | `true` | no |
 | controlplane\_internal | Toggle between public or private control plane load balancer | `bool` | `true` | no |
@@ -174,6 +174,7 @@ Optional policies have the option of being created by default, but are specified
 | ssh\_authorized\_keys | Server pool list of public keys to add as authorized ssh keys | `list(string)` | `[]` | no |
 | subnets | List of subnet IDs to create resources in | `list(string)` | n/a | yes |
 | tags | Map of tags to add to all resources created | `map(string)` | `{}` | no |
+| unique\_suffix | Enables/disables generation of a unique suffix to cluster name | `bool` | `true` | yes |
 | vpc\_id | VPC ID to create resources in | `string` | n/a | yes |
 
 ## Outputs
@@ -192,4 +193,3 @@ Optional policies have the option of being created by default, but are specified
 | server\_nodepool\_name | n/a |
 | server\_sg | n/a |
 | server\_url | n/a |
-

--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,7 @@ module "cp_lb" {
 
   enable_cross_zone_load_balancing = var.controlplane_enable_cross_zone_load_balancing
   internal                         = var.controlplane_internal
+  access_logs_bucket               = var.controlplane_access_logs_bucket
 
   cp_ingress_cidr_blocks            = var.controlplane_allowed_cidrs
   cp_supervisor_ingress_cidr_blocks = var.controlplane_allowed_cidrs

--- a/modules/elb/main.tf
+++ b/modules/elb/main.tf
@@ -74,5 +74,10 @@ resource "aws_elb" "controlplane" {
     unhealthy_threshold = 3
   }
 
+  access_logs {
+    bucket  = var.access_logs_bucket
+    enabled = var.access_logs_bucket != "disabled"
+  }
+
   tags = merge({}, var.tags)
 }

--- a/modules/elb/main.tf
+++ b/modules/elb/main.tf
@@ -75,6 +75,7 @@ resource "aws_elb" "controlplane" {
   }
 
   access_logs {
+    # the bucket name isn't allowed to be empty in this block, so use its default value as the flag
     bucket  = var.access_logs_bucket
     enabled = var.access_logs_bucket != "disabled"
   }

--- a/modules/elb/variables.tf
+++ b/modules/elb/variables.tf
@@ -44,3 +44,8 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "access_logs_bucket" {
+  type    = string
+  default = "disabled"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,12 @@ variable "controlplane_allowed_cidrs" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "controlplane_access_logs_bucket" {
+  description = "Bucket name for logging requests to control plane load balancer"
+  type        = string
+  default     = "disabled"
+}
+
 #
 # RKE2 Variables
 #


### PR DESCRIPTION
We deploy to an environment where we are required to enable access logging on our LB's.  This feature allows you to set the name of an existing S3 bucket where logs should go, and enables logging if this value is set. 