### PR TITLE
Feature/capacity timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Optional policies have the option of being created by default, but are specified
 | subnets | List of subnet IDs to create resources in | `list(string)` | n/a | yes |
 | tags | Map of tags to add to all resources created | `map(string)` | `{}` | no |
 | vpc\_id | VPC ID to create resources in | `string` | n/a | yes |
+| wait_for_capacity_timeout | How long Terraform should wait for ASG instances to be healthy before timing out. | `string` | `"10m"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -187,6 +187,7 @@ module "servers" {
   vpc_security_group_ids      = concat([aws_security_group.server.id, aws_security_group.cluster.id], var.extra_security_group_ids)
   spot                        = var.spot
   load_balancers              = [module.cp_lb.name]
+  wait_for_capacity_timeout   = var.wait_for_capacity_timeout
 
   # Overrideable variables
   userdata             = data.template_cloudinit_config.this.rendered

--- a/modules/agent-nodepool/README.md
+++ b/modules/agent-nodepool/README.md
@@ -27,7 +27,7 @@
 | subnets | List of subnet IDs to create resources in | `list(string)` | n/a | yes |
 | tags | Map of additional tags to add to all resources created | `map(string)` | `{}` | no |
 | vpc\_id | VPC ID to create resources in | `string` | n/a | yes |
-
+| wait_for_capacity_timeout | How long Terraform should wait for ASG instances to be healthy before timing out. | `string` | `"10m"` | no |
 ## Outputs
 
 | Name | Description |

--- a/modules/agent-nodepool/main.tf
+++ b/modules/agent-nodepool/main.tf
@@ -120,6 +120,7 @@ module "nodepool" {
   iam_instance_profile        = var.iam_instance_profile == "" ? module.iam[0].iam_instance_profile : var.iam_instance_profile
   asg                         = var.asg
   spot                        = var.spot
+  wait_for_capacity_timeout   = var.wait_for_capacity_timeout
 
   tags = merge({
     "Role" = "agent",

--- a/modules/agent-nodepool/variables.tf
+++ b/modules/agent-nodepool/variables.tf
@@ -156,6 +156,7 @@ variable "post_userdata" {
 }
 
 variable "wait_for_capacity_timeout" {
-  type    = number
-  default = "10m"
+  description = "How long Terraform should wait for ASG instances to be healthy before timing out."
+  type        = string
+  default     = "10m"
 }

--- a/modules/agent-nodepool/variables.tf
+++ b/modules/agent-nodepool/variables.tf
@@ -154,3 +154,8 @@ variable "post_userdata" {
   type        = string
   default     = ""
 }
+
+variable "wait_for_capacity_timeout" {
+  type    = number
+  default = "10m"
+}

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -63,9 +63,10 @@ resource "aws_autoscaling_group" "this" {
   desired_capacity = var.asg.desired
 
   # Health check and target groups dependent on whether we're a server or not (identified via rke2_url)
-  health_check_type = var.health_check_type
-  target_group_arns = var.target_group_arns
-  load_balancers    = var.load_balancers
+  health_check_type         = var.health_check_type
+  wait_for_capacity_timeout = var.wait_for_capacity_timeout
+  target_group_arns         = var.target_group_arns
+  load_balancers            = var.load_balancers
 
   min_elb_capacity = var.min_elb_capacity
 

--- a/modules/nodepool/variables.tf
+++ b/modules/nodepool/variables.tf
@@ -40,8 +40,9 @@ variable "health_check_type" {
 }
 
 variable "wait_for_capacity_timeout" {
-  type    = number
-  default = "10m"
+  description = "How long Terraform should wait for ASG instances to be healthy before timing out."
+  type        = string
+  default     = "10m"
 }
 
 variable "target_group_arns" {

--- a/modules/nodepool/variables.tf
+++ b/modules/nodepool/variables.tf
@@ -39,6 +39,11 @@ variable "health_check_type" {
   default = "EC2"
 }
 
+variable "wait_for_capacity_timeout" {
+  type    = number
+  default = "10m"
+}
+
 variable "target_group_arns" {
   type    = list(string)
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -152,6 +152,7 @@ variable "enable_ccm" {
 }
 
 variable "wait_for_capacity_timeout" {
-  type    = number
-  default = "10m"
+  description = "How long Terraform should wait for ASG instances to be healthy before timing out."
+  type        = string
+  default     = "10m"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -150,3 +150,8 @@ variable "enable_ccm" {
   type        = bool
   default     = false
 }
+
+variable "wait_for_capacity_timeout" {
+  type    = number
+  default = "10m"
+}


### PR DESCRIPTION
Adds the `wait_for_capacity_timeout` parameter to the ASG resource.   This is useful if someone was doing something dumb like copying 5gb of container image archives from S3 to `/var/lib/rancher/rke2/agent/images/` as part of the `pre_userdata` script.