### PR TITLE
Add Explicit MIME-type to S3 Object for rke2.yaml

### DIFF
--- a/modules/userdata/files/rke2-init.sh
+++ b/modules/userdata/files/rke2-init.sh
@@ -144,7 +144,7 @@ upload() {
   done
 
   # Replace localhost with server url and upload to s3 bucket
-  sed "s/127.0.0.1/${server_url}/g" /etc/rancher/rke2/rke2.yaml | aws s3 cp - "s3://${token_bucket}/rke2.yaml"
+  sed "s/127.0.0.1/${server_url}/g" /etc/rancher/rke2/rke2.yaml | aws s3 cp - "s3://${token_bucket}/rke2.yaml" --content-type "text/yaml"
 }
 
 pre_userdata() {


### PR DESCRIPTION
Adds an explicit `text/yaml` mime-type to s3 object for rke2.yaml so that s3 does not incorrectly guess the mime-type
See awscli docs: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3/cp.html

This allows for users of this module repo to utilize the aws terraform provider to pull the rke2.yaml content from s3