### PR TITLE
Updates for terraform aws module 4.x

### DIFF
--- a/modules/statestore/main.tf
+++ b/modules/statestore/main.tf
@@ -1,17 +1,23 @@
 resource "aws_s3_bucket" "bucket" {
   bucket        = lower("${var.name}-rke2")
-  acl           = "private"
   force_destroy = true
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
-      }
+  tags = merge({}, var.tags)
+}
+
+resource "aws_s3_bucket_acl" "acl" {
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ssec" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
     }
   }
-
-  tags = merge({}, var.tags)
 }
 
 resource "aws_s3_bucket_object" "token" {


### PR DESCRIPTION
Changes needed in order to use the latest AWS Terraform module: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#s3-bucket-refactor