### PR TITLE
Add missing IAM describe for autoscaler

### DIFF
--- a/modules/agent-nodepool/data.tf
+++ b/modules/agent-nodepool/data.tf
@@ -37,7 +37,8 @@ data "aws_iam_policy_document" "aws_autoscaler" {
       "autoscaling:DescribeTags",
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "ec2:DescribeLaunchTemplateVersions"
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes"
     ]
   }
 }


### PR DESCRIPTION
With the latest autoscaler, it does a query against InstanceTypes. This adds the necessary `ec2:DescribeInstanceTypes` action to fix that issue.