### PR TITLE
ignore changes to desired capacity

### DIFF
--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -111,6 +111,10 @@ resource "aws_autoscaling_group" "this" {
   }
 
   lifecycle {
-    ignore_changes = [load_balancers, target_group_arns]
+    ignore_changes = [
+      load_balancers,
+      target_group_arns,
+      desired_capacity
+    ]
   }
 }


### PR DESCRIPTION
By ignoring changes to `desired_capacity`, you can use autoscaling without constant drift.