### PR TITLE
fix: attach the nodepool security group to instances

### DIFF
--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -26,7 +26,7 @@ resource "aws_launch_template" "this" {
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     delete_on_termination       = true
-    security_groups             = var.vpc_security_group_ids
+    security_groups             = concat([aws_security_group.this.id], var.vpc_security_group_ids)
   }
 
   block_device_mappings {

--- a/modules/statestore/main.tf
+++ b/modules/statestore/main.tf
@@ -5,6 +5,19 @@ resource "aws_s3_bucket" "bucket" {
   tags = merge({}, var.tags)
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership" {
+  bucket = aws_s3_bucket.bucket
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+
+  # This `depends_on` is to prevent "A conflicting conditional operation is currently in progress against this resource."
+  depends_on = [
+    aws_s3_bucket.bucket
+  ]
+}
+
 resource "aws_s3_bucket_acl" "acl" {
   bucket = aws_s3_bucket.bucket.id
   acl    = "private"

--- a/modules/statestore/main.tf
+++ b/modules/statestore/main.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "bucket_ownership" {
-  bucket = aws_s3_bucket.bucket
+  bucket = aws_s3_bucket.bucket.id
 
   rule {
     object_ownership = "BucketOwnerPreferred"


### PR DESCRIPTION
### Motivation

Currently only the shared cluster security group is attached to the node pool instances, and the security group for node pool created in the `nodepool` module is neglected, which leads to the absence of a security group with the `kubernetes.io/cluster/<CLUSTERID>` tag required on AWS. Without this tag,  load balancer could not be auto provisioned on AWS.

### What this PR does

Alter the `nodepool` module to attach the security group which contains the `kubernetes.io/cluster/<CLUSTERID>` tag(passed by agent-nodepool https://github.com/rancherfederal/rke2-aws-tf/blob/2f9d27de1f1a59f7db58a37ecf42a330208a9dc3/modules/agent-nodepool/main.tf#L127-L129)  to the node pool instances.