### PR TITLE
feat: allow predefined security groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,8 @@ locals {
   cluster_data = {
     name       = local.uname
     server_url = module.cp_lb.dns
-    cluster_sg = aws_security_group.cluster.id
+    cluster_sg = var.security_group_cluster == "" ? aws_security_group.cluster[0].id : var.security_group_cluster
+    server_sg = var.security_group_server == "" ? aws_security_group.server[0].id : var.security_group_server
     token      = module.statestore.token
   }
   target_group_arns = module.cp_lb.target_group_arns
@@ -56,6 +57,7 @@ module "cp_lb" {
   internal                         = var.controlplane_internal
   access_logs_bucket               = var.controlplane_access_logs_bucket
 
+  security_group_controlplane       = var.security_group_server
   cp_ingress_cidr_blocks            = var.controlplane_allowed_cidrs
   cp_supervisor_ingress_cidr_blocks = var.controlplane_allowed_cidrs
 
@@ -68,6 +70,7 @@ module "cp_lb" {
 
 # Shared Cluster Security Group
 resource "aws_security_group" "cluster" {
+  count = var.security_group_cluster == "" ? 1 : 0
   name        = "${local.uname}-rke2-cluster"
   description = "Shared ${local.uname} cluster security group"
   vpc_id      = var.vpc_id
@@ -78,28 +81,31 @@ resource "aws_security_group" "cluster" {
 }
 
 resource "aws_security_group_rule" "cluster_shared" {
+  count = var.security_group_cluster == "" ? 1 : 0
   description       = "Allow all inbound traffic between ${local.uname} cluster nodes"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  security_group_id = aws_security_group.cluster.id
+  security_group_id = aws_security_group.cluster[0].id
   type              = "ingress"
 
   self = true
 }
 
 resource "aws_security_group_rule" "cluster_egress" {
+  count = var.security_group_cluster == "" ? 1 : 0
   description       = "Allow all outbound traffic"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
-  security_group_id = aws_security_group.cluster.id
+  security_group_id = aws_security_group.cluster[0].id
   type              = "egress"
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
 # Server Security Group
 resource "aws_security_group" "server" {
+  count = var.security_group_server == "" ? 1 : 0
   name        = "${local.uname}-rke2-server"
   vpc_id      = var.vpc_id
   description = "${local.uname} rke2 server node pool"
@@ -107,19 +113,21 @@ resource "aws_security_group" "server" {
 }
 
 resource "aws_security_group_rule" "server_cp" {
+  count = var.security_group_server == "" ? 1 : 0
   from_port                = 6443
   to_port                  = 6443
   protocol                 = "tcp"
-  security_group_id        = aws_security_group.server.id
+  security_group_id        = aws_security_group.server[0].id
   type                     = "ingress"
   source_security_group_id = module.cp_lb.security_group
 }
 
 resource "aws_security_group_rule" "server_cp_supervisor" {
+  count = var.security_group_server == "" ? 1 : 0
   from_port                = 9345
   to_port                  = 9345
   protocol                 = "tcp"
-  security_group_id        = aws_security_group.server.id
+  security_group_id        = aws_security_group.server[0].id
   type                     = "ingress"
   source_security_group_id = module.cp_lb.security_group
 }
@@ -186,7 +194,7 @@ module "servers" {
   instance_type               = var.instance_type
   block_device_mappings       = var.block_device_mappings
   extra_block_device_mappings = var.extra_block_device_mappings
-  vpc_security_group_ids      = concat([aws_security_group.server.id, aws_security_group.cluster.id, module.cp_lb.security_group], var.extra_security_group_ids)
+  vpc_security_group_ids      = distinct(concat([local.cluster_data.server_sg, local.cluster_data.cluster_sg, module.cp_lb.security_group], var.extra_security_group_ids))
   spot                        = var.spot
   #load_balancers              = [module.cp_lb.name]
   target_group_arns           = local.target_group_arns

--- a/modules/agent-nodepool/main.tf
+++ b/modules/agent-nodepool/main.tf
@@ -116,7 +116,7 @@ module "nodepool" {
   instance_type               = var.instance_type
   block_device_mappings       = var.block_device_mappings
   extra_block_device_mappings = var.extra_block_device_mappings
-  vpc_security_group_ids      = concat([var.cluster_data.cluster_sg], var.extra_security_group_ids)
+  vpc_security_group_ids      = distinct(concat([var.cluster_data.cluster_sg], var.extra_security_group_ids))
   userdata                    = data.cloudinit_config.init.rendered
   iam_instance_profile        = var.iam_instance_profile == "" ? module.iam[0].iam_instance_profile : var.iam_instance_profile
   asg                         = var.asg

--- a/modules/agent-nodepool/outputs.tf
+++ b/modules/agent-nodepool/outputs.tf
@@ -1,7 +1,3 @@
-output "security_group" {
-  value = module.nodepool.security_group
-}
-
 output "nodepool_name" {
   value = module.nodepool.asg_name
 }

--- a/modules/nlb/main.tf
+++ b/modules/nlb/main.tf
@@ -6,6 +6,7 @@ locals {
 }
 
 resource "aws_security_group" "controlplane" {
+  count = var.security_group_controlplane == "" ? 1 : 0
   name        = local.controlplane_name
   description = "${local.controlplane_name} sg"
   vpc_id      = var.vpc_id
@@ -14,30 +15,33 @@ resource "aws_security_group" "controlplane" {
 }
 
 resource "aws_security_group_rule" "apiserver" {
+  count = var.security_group_controlplane == "" ? 1 : 0
   from_port         = var.cp_port
   to_port           = var.cp_port
   protocol          = "tcp"
-  security_group_id = aws_security_group.controlplane.id
+  security_group_id = aws_security_group.controlplane[0].id
   type              = "ingress"
 
   cidr_blocks = var.cp_ingress_cidr_blocks
 }
 
 resource "aws_security_group_rule" "supervisor" {
+  count = var.security_group_controlplane == "" ? 1 : 0
   from_port         = var.cp_supervisor_port
   to_port           = var.cp_supervisor_port
   protocol          = "tcp"
-  security_group_id = aws_security_group.controlplane.id
+  security_group_id = aws_security_group.controlplane[0].id
   type              = "ingress"
 
   cidr_blocks = var.cp_supervisor_ingress_cidr_blocks
 }
 
 resource "aws_security_group_rule" "egress" {
+  count = var.security_group_controlplane == "" ? 1 : 0
   from_port         = "0"
   to_port           = "0"
   protocol          = "-1"
-  security_group_id = aws_security_group.controlplane.id
+  security_group_id = aws_security_group.controlplane[0].id
   type              = "egress"
 
   cidr_blocks = ["0.0.0.0/0"]

--- a/modules/nlb/outputs.tf
+++ b/modules/nlb/outputs.tf
@@ -15,7 +15,7 @@ output "name" {
 }
 
 output "security_group" {
-  value = aws_security_group.controlplane.id
+  value = var.security_group_controlplane == "" ? aws_security_group.controlplane[0].id : var.security_group_controlplane
 }
 
 output "target_group_arns" {

--- a/modules/nlb/variables.tf
+++ b/modules/nlb/variables.tf
@@ -20,6 +20,12 @@ variable "enable_cross_zone_load_balancing" {
   type    = bool
 }
 
+variable "security_group_controlplane" {
+  description = "security group for controlplane targets, created if left blank (default behavior)"
+  type        = string
+  default     = ""
+}
+
 variable "cp_port" {
   type    = number
   default = 6443

--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -1,12 +1,5 @@
 locals {}
 
-resource "aws_security_group" "this" {
-  name        = "${var.name}-rke2-nodepool"
-  vpc_id      = var.vpc_id
-  description = "${var.name} node pool"
-  tags        = merge({}, var.tags)
-}
-
 #
 # Launch template
 #

--- a/modules/nodepool/outputs.tf
+++ b/modules/nodepool/outputs.tf
@@ -17,7 +17,3 @@ output "asg_name" {
 output "asg_arn" {
   value = aws_autoscaling_group.this.arn
 }
-
-output "security_group" {
-  value = aws_security_group.this.id
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "server_url" {
 }
 
 output "server_sg" {
-  value = aws_security_group.server.id
+  value = local.cluster_data.server_sg
 }
 
 output "server_nodepool_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,18 @@ variable "ssh_authorized_keys" {
   default     = []
 }
 
+variable "security_group_cluster" {
+  description = "Security group shared by the cluster, created if left blank (default behavior)"
+  type        = string
+  default     = ""
+}
+
+variable "security_group_server" {
+  description = "Security group for server nodes, created if left blank (default behavior)"
+  type        = string
+  default     = ""
+}
+
 variable "extra_security_group_ids" {
   description = "List of additional security group IDs"
   type        = list(string)


### PR DESCRIPTION
Add variables to allow for preexisting security groups to be assigned to the server and cluster nodes. Useful for environments where the creation of security groups is prohibited by governance policies.