### PR TITLE
feat: s3 requires SSL by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Optional policies have the option of being created by default, but are specified
 | vpc\_id | VPC ID to create resources in | `string` | n/a | yes |
 | wait_for_capacity_timeout | How long Terraform should wait for ASG instances to be healthy before timing out. | `string` | `"10m"` | no |
 | metadata_options | Instance Metadata Options | `map` | <pre>{<br>  http_endpoint: "enabled",<br>  http_tokens: "required",<br>  http_put_response_hop_limit: 1,<br>  instance_metadata_tags: "disabled"}</pre> | no |
+| statestore_attach_deny_insecure_transport_policy | Toggle for enabling s3 policy to reject non-SSL requests | `bool` | `true` | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,8 @@ module "statestore" {
   name   = local.uname
   token  = random_password.token.result
   tags   = merge(local.default_tags, var.tags)
+
+  attach_deny_insecure_transport_policy = var.statestore_attach_deny_insecure_transport_policy
 }
 
 #

--- a/modules/statestore/variables.tf
+++ b/modules/statestore/variables.tf
@@ -10,3 +10,7 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "attach_deny_insecure_transport_policy" {
+  type = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -185,3 +185,12 @@ variable "extra_cloud_config_config" {
   default     = ""
 }
 
+#
+### Statestore Variables
+#
+
+variable "statestore_attach_deny_insecure_transport_policy" {
+  description = "Toggle for enabling s3 policy to reject non-SSL requests"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This PR enables a policy on the S3 bucket to require SSL connections.

This feature is turned on by default, but can be disabled through variables if necessary.

Satisfies this AWS Config rule: https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html