### PR TITLE
Add back agent sg to agent asg

### DIFF
--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -26,7 +26,7 @@ resource "aws_launch_template" "this" {
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
     delete_on_termination       = true
-    security_groups             = var.vpc_security_group_ids
+    security_groups             = concat(var.vpc_security_group_ids, [aws_security_group.this])
   }
 
   block_device_mappings {


### PR DESCRIPTION
The agent nodepool was not attaching its own security group to itself, only the shared sg for the entire cluster. This breaks communication with external resources only intended to happen from the agents.