### PR TITLE
fix: add aws_s3_bucket_ownership_controls resource for statestore module so ACL can be created.

### DIFF
--- a/modules/statestore/main.tf
+++ b/modules/statestore/main.tf
@@ -5,9 +5,25 @@ resource "aws_s3_bucket" "bucket" {
   tags = merge({}, var.tags)
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+
+  depends_on = [
+    aws_s3_bucket.bucket
+  ]
+}
+
 resource "aws_s3_bucket_acl" "acl" {
   bucket = aws_s3_bucket.bucket.id
   acl    = "private"
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.bucket_ownership
+  ]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "ssec" {

--- a/modules/statestore/main.tf
+++ b/modules/statestore/main.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "bucket" {
   tags = merge({}, var.tags)
 }
 
-resource "aws_s3_bucket_ownership_controls" "bucket_ownership" {
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
   bucket = aws_s3_bucket.bucket.id
 
   rule {
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_acl" "acl" {
   acl    = "private"
 
   depends_on = [
-    aws_s3_bucket_ownership_controls.bucket_ownership
+    aws_s3_bucket_ownership_controls.bucket_ownership_controls
   ]
 }
 


### PR DESCRIPTION
Turns out AWS has changed their default ACL behavior of S3 buckets since 2023/04: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

This PR adds `aws_s3_bucket_ownership_controls` to `statestore` module to mimic the default behavior before 2023.04 of AWS S3.