### PR TITLE
Fixed AccessControlListNotSupported error on setting ACL

### DIFF
--- a/modules/statestore/main.tf
+++ b/modules/statestore/main.tf
@@ -5,7 +5,18 @@ resource "aws_s3_bucket" "bucket" {
   tags = merge({}, var.tags)
 }
 
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
+  bucket = aws_s3_bucket.bucket.id
+  
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "acl" {
+  depends_on = [
+    aws_s3_bucket_ownership_controls.bucket_ownership_controls
+  ]
   bucket = aws_s3_bucket.bucket.id
   acl    = "private"
 }


### PR DESCRIPTION
Reason: Changes in AWS default settings which broke the working code
> Starting in April 2023, Amazon S3 will change the default settings for S3 Block Public Access and Object Ownership (ACLs disabled) for all new S3 buckets. For new buckets created after this update, all S3 Block Public Access settings will be enabled, and S3 access control lists (ACLs) will be disabled. 
+ Changed the Object Ownership to `BucketOwnerPreferred` so that we can set `acl` to be `"private"` as before.