### PR TITLE
Make rke2 config init concat to rke2 config file instead of overwrite…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ rke2.yaml
 admin.conf
 
 **.DS_Store
+examples/test-*

--- a/modules/userdata/files/rke2-init.sh
+++ b/modules/userdata/files/rke2-init.sh
@@ -26,7 +26,7 @@ timestamp() {
 
 config() {
   mkdir -p "/etc/rancher/rke2"
-  cat <<EOF > "/etc/rancher/rke2/config.yaml"
+  cat <<EOF >> "/etc/rancher/rke2/config.yaml"
 # Additional user defined configuration
 ${config}
 EOF


### PR DESCRIPTION
Make rke2 config init concat to rke2 config file instead of overwriting it so we can add to it before rke2 is installed