### PR TITLE
fix: do not pass metadata_options if variable is null

### DIFF
--- a/modules/nodepool/main.tf
+++ b/modules/nodepool/main.tf
@@ -16,11 +16,14 @@ resource "aws_launch_template" "this" {
   instance_type = var.instance_type
   user_data     = var.userdata
 
-  metadata_options {
-    http_endpoint               = var.metadata_options["http_endpoint"]
-    http_tokens                 = var.metadata_options["http_tokens"]
-    http_put_response_hop_limit = var.metadata_options["http_put_response_hop_limit"]
-    instance_metadata_tags      = var.metadata_options["instance_metadata_tags"]
+  dynamic "metadata_options" {
+    for_each = (var.metadata_options == null) ? [] : [1]
+    content {
+      http_endpoint               = var.metadata_options["http_endpoint"]
+      http_tokens                 = var.metadata_options["http_tokens"]
+      http_put_response_hop_limit = var.metadata_options["http_put_response_hop_limit"]
+      instance_metadata_tags      = var.metadata_options["instance_metadata_tags"]
+    }
   }
 
   network_interfaces {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6"
+      version = ">= 5"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"


### PR DESCRIPTION
Setting the `metadata_options` explicitly in the AWS launch template is not supported in certain regions. The error we get is:
```
You must use a valid fully formed launch template; specifing HttpProtocol metadata options for an instance is not supported in this region.
```
This fix sets the `metadata_options` only if the value passed in is not `null`.

As described in https://github.com/hashicorp/terraform-provider-aws/issues/25227, version 5.0.0 of the `terraform-provider-aws` fixed the issue of removing default values from the launch template. Hence this fix also upgrades the AWS terraform provider to that new version.