### PR TITLE
docs: fix readme usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains 2 terraform modules intended for user consumption:
 # Provision rke2 server(s) and controlplane loadbalancer
 module "rke2" {
   source  = "git::https://github.com/rancherfederal/rke2-aws-tf.git"
-  name    = "quickstart"
+  cluster_name    = "quickstart"
   vpc_id  = "vpc-###"
   subnets = ["subnet-###"]
   ami     = "ami-###"


### PR DESCRIPTION
Readme Usage example should use `cluster_name` instead of `name` for input variable.