### PR TITLE
fix: container-selinux rpm url update

### DIFF
--- a/modules/common/download.sh
+++ b/modules/common/download.sh
@@ -81,7 +81,7 @@ do_download() {
     7*)
       if [ $ID == "rhel" ]; then
         rpm --import http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
-        yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.119.2-1.911c772.el7_8.noarch.rpm
+        yum install -y http://vault.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.119.2-1.911c772.el7_8.noarch.rpm
       fi
       INSTALL_RKE2_METHOD='yum' INSTALL_RKE2_TYPE="${type}" ./install.sh
 


### PR DESCRIPTION
The container-selinux package has been moved to the centos vault, updated URL to support.