### PR TITLE
Fix endless loop on leader node for RKE2 1.34

### DIFF
--- a/modules/userdata/files/rke2-init.sh
+++ b/modules/userdata/files/rke2-init.sh
@@ -113,7 +113,7 @@ local_cp_api_wait() {
   wait $!
 
   nodereadypath='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
-  until kubectl get nodes --selector='node-role.kubernetes.io/master' -o jsonpath="$nodereadypath" | grep -E "Ready=True"; do
+  until kubectl get nodes --selector='node-role.kubernetes.io/master' -o jsonpath="$nodereadypath" | grep -E "Ready=True" || kubectl get nodes --selector='node-role.kubernetes.io/control-plane' -o jsonpath="$nodereadypath" | grep -E "Ready=True"; do
     info "$(timestamp) Waiting for servers to be ready..."
     sleep 5
   done


### PR DESCRIPTION
In the latest RKE2 version (1.34), the `master` role no longer exists, which causes an endless loop during initialization on the leader node. This change should fix the issue.