### PR TITLE
create restriction on control plane cluster size

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -212,10 +212,10 @@ module "servers" {
   userdata             = data.cloudinit_config.this.rendered
   iam_instance_profile = var.iam_instance_profile == "" ? module.iam[0].iam_instance_profile : var.iam_instance_profile
 
-  # Don't allow something not recommended within etcd scaling, set max deliberately and only control desired
+  # Control plane should not autoscale
   asg = {
-    min                  = 1
-    max                  = 7
+    min                  = var.servers
+    max                  = var.servers
     desired              = var.servers
     suspended_processes  = var.suspended_processes
     termination_policies = var.termination_policies

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,15 @@ variable "servers" {
   description = "Number of servers to create"
   type        = number
   default     = 3
+
+  validation {
+    condition = (
+      var.servers == 1 ||
+      var.servers == 3 ||
+      var.servers == 5
+    )
+    error_message = "Servers must an odd number <= 5. See https://etcd.io/docs/v3.6/faq/#why-an-odd-number-of-cluster-members."
+  }
 }
 
 variable "spot" {


### PR DESCRIPTION
Add restriction on number of control plane nodes. These are:
- Odd number less than or equal to 5
- Min size, max size, and desired capacity should all be equal

`etcd` itself places on restriction on cluster size, but notes that an odd number is preferred because no additional redundancy is achieved with even numbers due to how Raft voting works. The maximum of 5 is empirical from Google's experience with the Chubby distributed lock system and the fact that write latency starts to grow unacceptably large with larger clusters.

This may need to be revisited in the future because `kine` is now supported by `rke2` and allows the use of an external data store, such that an HA control plane may have an even number of nodes without losing anything if this is being used.